### PR TITLE
refactor: use dictionary to maintain records

### DIFF
--- a/lib/services/in-memory-db.service.ts
+++ b/lib/services/in-memory-db.service.ts
@@ -3,37 +3,144 @@ import { InMemoryDBEntity } from '../interfaces';
 
 @Injectable()
 export class InMemoryDBService<T extends InMemoryDBEntity> {
-  public records: T[] = [];
+  private recordMap: { [id: number]: T } = {};
 
+  /**
+   * Given the array of records of type `T`, reduce the array into a dictionary object of
+   * type `{ [id: number]: T }`. Set the value of the `recordMap` to this reduced input array.
+   * Example:
+   *
+   * - input array
+   * ```json5
+   * [
+   *  {
+   *    "id": 1,
+   *    "prop": "test1"
+   *  },
+   *  {
+   *    "id": 2,
+   *    "prop": "test2"
+   *  }
+   * ]
+   * ```
+   * - becomes
+   * ```json5
+   * {
+   *    1: { "id": 1, "prop": "test1" },
+   *    2: { "id": 2, "prop": "test2" }
+   * }
+   * ```
+   * @param records the array of records of type T
+   */
+  set records(records: T[]) {
+    if (!records || records.length === 0) {
+      this.recordMap = {};
+    }
+    this.recordMap = records.reduce(
+      (previous: { [id: number]: T }, current: T) => {
+        return {
+          ...previous,
+          [current.id]: current,
+        };
+      },
+      this.recordMap,
+    );
+  }
+  get records(): T[] {
+    return Object.keys(this.recordMap).map(key => this.recordMap[key]);
+  }
+
+  /**
+   * Add the supplied `record` partial to the `recordMap` in-memory data store of records.
+   * Get the `id` of the record by getting the next available `id` value.
+   * Returns the `id` of the newly added record.
+   * @param record the partial record of type `T` to create
+   */
   public create(record: Partial<T>): number {
     const id = record.id || this.getNextId();
     const newRecord: T = { ...record, id } as T;
-    this.records.push(newRecord);
+    this.recordMap = {
+      ...this.recordMap,
+      [id]: newRecord,
+    };
     return newRecord.id;
   }
 
+  /**
+   * Update a record in the `recordMap` of type `T` using the supplied record.
+   * @param record the record of type `T` to update
+   */
   public update(record: T): void {
-    const foundRecordIndex = this.records.findIndex(r => r.id === record.id);
-    this.records[foundRecordIndex] = { ...record };
+    this.recordMap = {
+      ...this.recordMap,
+      [record.id]: record,
+    };
   }
 
-  public delete(id: number) {
-    const foundRecordIndex = this.records.findIndex(r => r.id === id);
-    this.records.splice(foundRecordIndex);
+  /**
+   * Remove the record of type `T` from the `recordMap` using the supplied PK id.
+   * @param id the PK id of the record
+   */
+  public delete(id: number): void {
+    const { [id]: removed, ...remainder } = this.recordMap;
+    this.recordMap = {
+      ...remainder,
+    };
   }
 
+  /**
+   * Get a single record of type `T` with the supplid id value.
+   * @param id the PK id of the record
+   */
   public get(id: number): T {
-    return this.records.find(r => r.id === id);
+    return this.recordMap[id];
   }
 
+  /**
+   * Return all of the records of type `T`.
+   */
   public getAll(): T[] {
     return this.records || [];
   }
 
+  /**
+   * Return an array of records of type `T` filtered with the supplied predicate.
+   * Example:
+   * - given records:
+   * ```json5
+   * [
+   *  {
+   *    "id": 1,
+   *    "prop": "test1"
+   *  },
+   *  {
+   *    "id": 2,
+   *    "prop": "test2"
+   *  }
+   * ]
+   * ```
+   * - to find records with a `prop` value of `test1`:
+   * ```ts
+   * const records: T[] = service.query(record => record.prop === 'test1');
+   * ```
+   * @param predicate the filter predicate
+   */
   public query(predicate: (record: T) => boolean) {
     return this.records.filter(predicate);
   }
 
+  /**
+   * get the next id by finding the max id in the current records array and adding 1 to that value.
+   * Example:
+   * - current `recordMap`
+   * ```json5
+   * {
+   *    1: { "id": 1, "prop": "test1" },
+   *    4: { "id": 4, "prop": "test2" }
+   * }
+   * ```
+   * - next next id would be: `5` as the current highest id is `4` + `1` = `5`.
+   */
   private getNextId(): number {
     if (this.records && this.records.length > 0) {
       return Math.max(...this.records.map(r => r.id)) + 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestjs-addons/in-memory-db",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
**Issues**
This PR is to resolve Issue #1  - delete method is not deleting record.

**Description of work**
Switch from using an array to house records in memory to using a dictionary object of the record type. Switch methods to utilize this dictionary object instead of the array. Resolved delete by use of destructuring dictionary object to pull out remaining entities and updating the `recordMap` to be these remaining entities.
Added `tsdoc` comments to methods.

