### PR TITLE
feat: implementing forFeature

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,29 +61,6 @@ As you can see we did the following:
 - Import `InMemoryDBModule` from `@nestjs-addons/in-memory-db`
 - Add `InMemoryDBModule` to the `imports` array in the `@Module` of your choice
 
-#### Registering a forFeature InMemoryDBService
-
-```typescript
-// feature-one.module.ts
-
-import { Module } from '@nestjs/common';
-import { InMemoryDBModule } from '@nestjs-addons/in-memory-db';
-...
-
-@Module({
-  ...
-  imports: [InMemoryDBModule.forFeature('one')],
-  ...
-})
-export class FeatureOneModule {}
-```
-
-As you can see we did the following:
-
-- Import `InMemoryDBModule` from `@nestjs-addons/in-memory-db`
-- Add `InMemoryDBModule` to the `imports` array in the `@Module` of your choice
-- Added the `forFeature` method call passing `one` as the feature name
-
 ### Define an interface for each InMemoryEntity
 
 An instance of `InMemoryDBService<T>` will be created for each `InMemoryEntity` entity `interface` defined. The `InMemoryEntity` adds an `id: number` property as the only required field. Additional fields can be defined by extending the `interface`.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ import { InMemoryDBModule } from '@nestjs-addons/in-memory-db';
 
 @Module({
   ...
-  imports: [InMemoryDBModule.forRoot()],
+  imports: [InMemoryDBModule.forRoot({})],
   ...
 })
 export class AppModule {}
@@ -121,7 +121,7 @@ import { InMemoryDBModule } from '@nestjs-addons/in-memory-db';
 
 @Module({
   ...
-  imports: [InMemoryDBModule.forFeature('one')],
+  imports: [InMemoryDBModule.forFeature('one', {})],
   ...
 })
 export class FeatureOneModule {}

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ To get started, let's first update our `app.module.ts` to include the necessary 
 
 > While we are importing to the AppModule in this example, InMemoryDBModule could be imported in Feature modules just as well.
 
+#### Registering a forRoot InMemoryDBService
+
 ```typescript
 // app.module.ts
 
@@ -58,6 +60,29 @@ As you can see we did the following:
 
 - Import `InMemoryDBModule` from `@nestjs-addons/in-memory-db`
 - Add `InMemoryDBModule` to the `imports` array in the `@Module` of your choice
+
+#### Registering a forFeature InMemoryDBService
+
+```typescript
+// feature-one.module.ts
+
+import { Module } from '@nestjs/common';
+import { InMemoryDBModule } from '@nestjs-addons/in-memory-db';
+...
+
+@Module({
+  ...
+  imports: [InMemoryDBModule.forFeature('one')],
+  ...
+})
+export class FeatureOneModule {}
+```
+
+As you can see we did the following:
+
+- Import `InMemoryDBModule` from `@nestjs-addons/in-memory-db`
+- Add `InMemoryDBModule` to the `imports` array in the `@Module` of your choice
+- Added the `forFeature` method call passing `one` as the feature name
 
 ### Define an interface for each InMemoryEntity
 
@@ -101,6 +126,53 @@ export class UserController {
   }
 }
 ```
+
+## Feature Modules - Registering Multiple Instances using `forFeature`
+
+Registering multiple instances for specific feature modules is super simple. Each feature module is guaranteed isolated to that feature. In order to get up and running you need to do the following:
+
+#### Registering a forFeature InMemoryDBService
+
+For each feature module(s), do the following:
+
+```typescript
+// feature-one.module.ts
+
+import { Module } from '@nestjs/common';
+import { InMemoryDBModule } from '@nestjs-addons/in-memory-db';
+...
+
+@Module({
+  ...
+  imports: [InMemoryDBModule.forFeature('one')],
+  ...
+})
+export class FeatureOneModule {}
+```
+
+As you can see we:
+
+- Imported `InMemoryDBModule` from `@nestjs-addons/in-memory-db`
+- Added `InMemoryDBModule` to the `imports` array in the `@Module` of your choice
+- Added the `forFeature` method call passing `one` as the feature name
+
+#### Using the Feature Instance
+
+If you would like to use the feature-specific instance, make use of the included `@InjectInMemoryDBService` decorator:
+
+```typescript
+@Controller({...})
+export class FeatureOneController {
+  constructor(@InjectInMemoryDBService('one') private oneService: InMemoryDBService<OneEntity>) {}
+  ...
+  @Get()
+  getAll(): OneEntity[] {
+    return this.oneService.getAll();
+  }
+}
+```
+
+Using this decorator ensures that the correct instance is injected.
 
 ## Docs
 

--- a/lib/common/in-memory-db.constants.ts
+++ b/lib/common/in-memory-db.constants.ts
@@ -1,0 +1,2 @@
+export const IN_MEMORY_DB_SERVICE = 'InMemoryDBService';
+export const IN_MEMORY_DB_CONFIG = 'InMemoryDBConfig';

--- a/lib/common/in-memory-db.decorators.ts
+++ b/lib/common/in-memory-db.decorators.ts
@@ -1,0 +1,5 @@
+import { Inject } from '@nestjs/common';
+import { getInMemoryDBServiceToken } from './in-memory-db.utils';
+
+export const InjectInMemoryDBService = (featureName: string) =>
+  Inject(getInMemoryDBServiceToken(featureName));

--- a/lib/common/in-memory-db.utils.spec.ts
+++ b/lib/common/in-memory-db.utils.spec.ts
@@ -1,0 +1,19 @@
+import { getInMemoryDBServiceToken } from './in-memory-db.utils';
+
+describe('getInMemoryDBServiceToken', () => {
+  test.each([
+    ['oneInMemoryDBService', 'one'],
+    ['InMemoryDBService', ''],
+    ['InMemoryDBService', null],
+    ['InMemoryDBService', undefined],
+  ])(
+    'should return %p token given input featureName of %p',
+    (expectedToken: string, featureName: string) => {
+      // act
+      const actualToken = getInMemoryDBServiceToken(featureName);
+
+      // assert
+      expect(actualToken).toEqual(expectedToken);
+    },
+  );
+});

--- a/lib/common/in-memory-db.utils.ts
+++ b/lib/common/in-memory-db.utils.ts
@@ -1,0 +1,7 @@
+import { IN_MEMORY_DB_SERVICE } from './in-memory-db.constants';
+
+export function getInMemoryDBServiceToken(featureName?: string) {
+  return featureName && featureName !== IN_MEMORY_DB_SERVICE
+    ? `${featureName}${IN_MEMORY_DB_SERVICE}`
+    : IN_MEMORY_DB_SERVICE;
+}

--- a/lib/common/index.ts
+++ b/lib/common/index.ts
@@ -1,0 +1,2 @@
+export * from './in-memory-db.decorators';
+export { getInMemoryDBServiceToken } from './in-memory-db.utils';

--- a/lib/factories/in-memory-db-service.factory.ts
+++ b/lib/factories/in-memory-db-service.factory.ts
@@ -1,0 +1,15 @@
+import { InMemoryDBConfig, InMemoryDBEntity } from '../interfaces';
+import { InMemoryDBService } from '../services';
+
+export function inMemoryDBServiceFactory<T extends InMemoryDBEntity>(
+  featureConfig: Partial<InMemoryDBConfig> = {},
+  featureName?: string,
+) {
+  return () =>
+    new InMemoryDBService<T>({
+      featureName: featureName
+        ? featureName
+        : featureConfig.featureName || 'root',
+      ...featureConfig,
+    });
+}

--- a/lib/factories/index.ts
+++ b/lib/factories/index.ts
@@ -1,0 +1,1 @@
+export * from './in-memory-db-service.factory';

--- a/lib/in-memory-db.module.ts
+++ b/lib/in-memory-db.module.ts
@@ -2,22 +2,33 @@ import { DynamicModule, Module } from '@nestjs/common';
 
 import { InMemoryDBConfig } from './interfaces';
 import { InMemoryDBService } from './services';
-
+import {
+  createInMemoryDBForRootProviders,
+  createInMemoryDBForFeatureProviders,
+} from './providers';
 @Module({
   providers: [InMemoryDBService],
   exports: [InMemoryDBService],
 })
 export class InMemoryDBModule {
   public static forRoot(config: Partial<InMemoryDBConfig> = {}): DynamicModule {
+    const providers = createInMemoryDBForRootProviders(config);
     return {
       module: InMemoryDBModule,
-      providers: [
-        {
-          provide: InMemoryDBService,
-          useValue: new InMemoryDBService(config),
-        },
-      ],
-      exports: [InMemoryDBService],
+      providers,
+      exports: providers,
+    };
+  }
+
+  public static forFeature(
+    featureName: string,
+    config: Partial<InMemoryDBConfig> = {},
+  ): DynamicModule {
+    const providers = createInMemoryDBForFeatureProviders(featureName, config);
+    return {
+      module: InMemoryDBModule,
+      providers,
+      exports: providers,
     };
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,7 @@
 import 'reflect-metadata';
+import { InjectInMemoryDBService } from './common';
+
 export * from './in-memory-db.module';
 export * from './interfaces';
 export * from './services';
+export { InjectInMemoryDBService };

--- a/lib/interfaces/in-memory-db-config.ts
+++ b/lib/interfaces/in-memory-db-config.ts
@@ -1,2 +1,8 @@
-// tslint:disable-next-line: no-empty-interface
-export interface InMemoryDBConfig {}
+/**
+ * InMemoryDBConfig defines the config settings for InMemoryDBModule
+ *
+ * All properties should remain optional except featureName
+ */
+export interface InMemoryDBConfig {
+  featureName: string;
+}

--- a/lib/providers/in-memory-db-for-feature.providers.spec.ts
+++ b/lib/providers/in-memory-db-for-feature.providers.spec.ts
@@ -1,0 +1,36 @@
+import { FactoryProvider } from '@nestjs/common/interfaces';
+
+import { getInMemoryDBServiceToken } from '../common/in-memory-db.utils';
+import { createInMemoryDBForFeatureProviders } from './in-memory-db-for-feature.providers';
+import { InMemoryDBConfig } from '../interfaces';
+import { inMemoryDBServiceFactory } from '../factories';
+
+describe('createInMemoryDBForFeatureProviders', () => {
+  test('returns correct providers array given featureName and featureConfig', () => {
+    // arrange
+    const inputFeatureName = 'myFeature';
+    const inputFeatureConfig: Partial<InMemoryDBConfig> = {};
+
+    const expectedProviders: Array<FactoryProvider<any>> = [
+      {
+        provide: getInMemoryDBServiceToken(inputFeatureName),
+        useFactory: inMemoryDBServiceFactory(
+          inputFeatureConfig,
+          inputFeatureName,
+        ),
+      },
+    ];
+
+    // act
+    const actualProviders = createInMemoryDBForFeatureProviders(
+      inputFeatureName,
+      inputFeatureConfig,
+    );
+
+    // assert
+    expect(actualProviders[0].provide).toEqual(expectedProviders[0].provide);
+    expect(actualProviders[0].useFactory()).toEqual(
+      expectedProviders[0].useFactory(),
+    );
+  });
+});

--- a/lib/providers/in-memory-db-for-feature.providers.ts
+++ b/lib/providers/in-memory-db-for-feature.providers.ts
@@ -1,13 +1,13 @@
 import { InMemoryDBConfig } from '../interfaces';
-import { Provider } from '@nestjs/common';
 import { getInMemoryDBServiceToken } from '../common';
 import { inMemoryDBServiceFactory } from '../factories';
+import { FactoryProvider } from '@nestjs/common/interfaces';
 
 export function createInMemoryDBForFeatureProviders(
   featureName: string,
   featureConfig: Partial<InMemoryDBConfig> = {},
 ) {
-  const providers: Provider[] = [
+  const providers: FactoryProvider[] = [
     {
       provide: getInMemoryDBServiceToken(featureName),
       useFactory: inMemoryDBServiceFactory(featureConfig, featureName),

--- a/lib/providers/in-memory-db-for-feature.providers.ts
+++ b/lib/providers/in-memory-db-for-feature.providers.ts
@@ -1,0 +1,17 @@
+import { InMemoryDBConfig } from '../interfaces';
+import { Provider } from '@nestjs/common';
+import { getInMemoryDBServiceToken } from '../common';
+import { inMemoryDBServiceFactory } from '../factories';
+
+export function createInMemoryDBForFeatureProviders(
+  featureName: string,
+  featureConfig: Partial<InMemoryDBConfig> = {},
+) {
+  const providers: Provider[] = [
+    {
+      provide: getInMemoryDBServiceToken(featureName),
+      useFactory: inMemoryDBServiceFactory(featureConfig, featureName),
+    },
+  ];
+  return providers;
+}

--- a/lib/providers/in-memory-db-for-root.providers.spec.ts
+++ b/lib/providers/in-memory-db-for-root.providers.spec.ts
@@ -1,0 +1,31 @@
+import { FactoryProvider } from '@nestjs/common/interfaces';
+
+import { getInMemoryDBServiceToken } from '../common/in-memory-db.utils';
+import { createInMemoryDBForRootProviders } from './in-memory-db-for-root.providers';
+import { InMemoryDBConfig } from '../interfaces';
+import { inMemoryDBServiceFactory } from '../factories';
+
+describe('createInMemoryDBForRootProviders', () => {
+  test('returns correct providers array given featureName and featureConfig', () => {
+    // arrange
+    const inputFeatureConfig: Partial<InMemoryDBConfig> = {};
+
+    const expectedProviders: Array<FactoryProvider<any>> = [
+      {
+        provide: getInMemoryDBServiceToken(),
+        useFactory: inMemoryDBServiceFactory(inputFeatureConfig),
+      },
+    ];
+
+    // act
+    const actualProviders = createInMemoryDBForRootProviders(
+      inputFeatureConfig,
+    );
+
+    // assert
+    expect(actualProviders[0].provide).toEqual(expectedProviders[0].provide);
+    expect(actualProviders[0].useFactory()).toEqual(
+      expectedProviders[0].useFactory(),
+    );
+  });
+});

--- a/lib/providers/in-memory-db-for-root.providers.ts
+++ b/lib/providers/in-memory-db-for-root.providers.ts
@@ -1,0 +1,16 @@
+import { inMemoryDBServiceFactory } from '../factories';
+import { getInMemoryDBServiceToken } from '../common';
+import { Provider } from '@nestjs/common';
+import { InMemoryDBConfig } from '../interfaces';
+
+export function createInMemoryDBForRootProviders(
+  featureConfig: Partial<InMemoryDBConfig> = {},
+) {
+  const providers: Provider[] = [
+    {
+      provide: getInMemoryDBServiceToken(),
+      useFactory: inMemoryDBServiceFactory(featureConfig),
+    },
+  ];
+  return providers;
+}

--- a/lib/providers/in-memory-db-for-root.providers.ts
+++ b/lib/providers/in-memory-db-for-root.providers.ts
@@ -1,12 +1,13 @@
+import { FactoryProvider } from '@nestjs/common/interfaces';
+
 import { inMemoryDBServiceFactory } from '../factories';
 import { getInMemoryDBServiceToken } from '../common';
-import { Provider } from '@nestjs/common';
 import { InMemoryDBConfig } from '../interfaces';
 
 export function createInMemoryDBForRootProviders(
   featureConfig: Partial<InMemoryDBConfig> = {},
 ) {
-  const providers: Provider[] = [
+  const providers: FactoryProvider[] = [
     {
       provide: getInMemoryDBServiceToken(),
       useFactory: inMemoryDBServiceFactory(featureConfig),

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -1,0 +1,2 @@
+export * from './in-memory-db-for-root.providers';
+export * from './in-memory-db-for-feature.providers';

--- a/lib/services/in-memory-db.service.spec.ts
+++ b/lib/services/in-memory-db.service.spec.ts
@@ -1,6 +1,7 @@
 import { marbles } from 'rxjs-marbles';
 import { InMemoryDBEntity } from '../interfaces';
 import { InMemoryDBService } from './in-memory-db.service';
+import { inMemoryDBServiceFactory } from '../factories';
 
 describe('In Memory DB Service', () => {
   interface TestEntity extends InMemoryDBEntity {
@@ -16,11 +17,11 @@ describe('In Memory DB Service', () => {
   ];
 
   beforeEach(() => {
-    service = new InMemoryDBService<TestEntity>();
+    service = inMemoryDBServiceFactory<TestEntity>()();
   });
 
   describe('get', () => {
-    it('should return expected record if given valid id', () => {
+    test('should return expected record if given valid id', () => {
       // arrange
       service.records = [...sampleRecords];
       const expectedRecord = sampleRecords[0];
@@ -32,7 +33,7 @@ describe('In Memory DB Service', () => {
       expect(actualRecord).toEqual(expectedRecord);
     });
 
-    it('should return undefined if given invalid id', () => {
+    test('should return undefined if given invalid id', () => {
       // arrange
       service.records = [...sampleRecords];
       const expectedRecord = undefined;
@@ -46,7 +47,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('getAsync', () => {
-    it(
+    test(
       'should return expected record as an observable if given valid id',
       marbles(m => {
         // arrange
@@ -61,7 +62,7 @@ describe('In Memory DB Service', () => {
       }),
     );
 
-    it(
+    test(
       'should return observable with no value given invalid id',
       marbles(m => {
         // arrange
@@ -78,7 +79,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('getMany', () => {
-    it('should return expected records if given valid ids', () => {
+    test('should return expected records if given valid ids', () => {
       // arrange
       service.records = [...sampleRecords];
       const expectedRecords = [...[sampleRecords[0], sampleRecords[1]]];
@@ -90,7 +91,7 @@ describe('In Memory DB Service', () => {
       expect(actualRecords).toEqual(expectedRecords);
     });
 
-    it('should return only expected records if given an invalid id', () => {
+    test('should return only expected records if given an invalid id', () => {
       // arrange
       service.records = [...sampleRecords];
       const expectedRecords = [sampleRecords[0]];
@@ -104,7 +105,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('getManyAsync', () => {
-    it(
+    test(
       'should return expected records as observable if given valid ids',
       marbles(m => {
         // arrange
@@ -121,7 +122,7 @@ describe('In Memory DB Service', () => {
       }),
     );
 
-    it(
+    test(
       'should return only expected records as observables if given an invalid id',
       marbles(m => {
         // arrange
@@ -138,7 +139,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('getAll', () => {
-    it('should return all expected records', () => {
+    test('should return all expected records', () => {
       // arrange
       service.records = [...sampleRecords];
       const expectedRecords = service.records;
@@ -149,7 +150,7 @@ describe('In Memory DB Service', () => {
       // assert
       expect(actualRecords).toEqual(expectedRecords);
     });
-    it('should return empty array if no records', () => {
+    test('should return empty array if no records', () => {
       // arrange
       service.records = [];
       const expectedRecords = [];
@@ -163,7 +164,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('getAllAsync', () => {
-    it(
+    test(
       'should return all expected records as observable',
       marbles(m => {
         // arrange
@@ -177,7 +178,7 @@ describe('In Memory DB Service', () => {
         m.expect(actualRecords).toBeObservable(expectedRecords);
       }),
     );
-    it(
+    test(
       'should return empty array as observable if no records',
       marbles(m => {
         // arrange
@@ -194,7 +195,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('create', () => {
-    it('should update records with correct items', () => {
+    test('should update records with correct items', () => {
       // arrange
       service.records = [];
       const itemToAdd: Partial<TestEntity> = { someField: 'Test' };
@@ -206,7 +207,7 @@ describe('In Memory DB Service', () => {
       // assert
       expect(service.records).toEqual(expectedRecords);
     });
-    it('should return generated id', () => {
+    test('should return generated id', () => {
       // arrange
       service.records = [];
       const itemToAdd: Partial<TestEntity> = { someField: 'Test' };
@@ -221,7 +222,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('createAsync', () => {
-    it(
+    test(
       'should update records with correct items asyncronously',
       marbles(m => {
         // arrange
@@ -237,7 +238,7 @@ describe('In Memory DB Service', () => {
         m.expect(actualRecords).toBeObservable(expectedRecords);
       }),
     );
-    it(
+    test(
       'should return generated id as observable',
       marbles(m => {
         // arrange
@@ -255,7 +256,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('createMany', () => {
-    it('should update records with correct items', () => {
+    test('should update records with correct items', () => {
       // arrange
       service.records = [];
       const item1ToAdd: Partial<TestEntity> = { someField: 'Test' };
@@ -271,7 +272,7 @@ describe('In Memory DB Service', () => {
       expect(service.records).toEqual(expectedRecords);
       expect(createdRecords).toEqual(expectedRecords);
     });
-    it('should return generated ids', () => {
+    test('should return generated ids', () => {
       // arrange
       service.records = [];
       const item1ToAdd: Partial<TestEntity> = { someField: 'Test' };
@@ -294,7 +295,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('createManyAsync', () => {
-    it(
+    test(
       'should update records with correct items asynchronously',
       marbles(m => {
         // arrange
@@ -317,7 +318,7 @@ describe('In Memory DB Service', () => {
         m.expect(createdRecords).toBeObservable(expectedRecords);
       }),
     );
-    it(
+    test(
       'should return generated ids asyncronously',
       marbles(m => {
         // arrange
@@ -345,7 +346,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('update', () => {
-    it('should update record as expected', () => {
+    test('should update record as expected', () => {
       // arrange
       const originalRecord: TestEntity = { id: 1, someField: 'AAA' };
       const expectedUpdatedRecord: TestEntity = { id: 1, someField: 'BBB' };
@@ -364,7 +365,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('updateAsync', () => {
-    it(
+    test(
       'should update record as expected asyncronously',
       marbles(m => {
         // arrange
@@ -388,7 +389,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('updateMany', () => {
-    it('should update records as expected', () => {
+    test('should update records as expected', () => {
       // arrange
       const originalRecords: TestEntity[] = [
         { id: 1, someField: 'AAA' },
@@ -414,7 +415,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('updateManyAsync', () => {
-    it(
+    test(
       'should update records as expected asynronously',
       marbles(m => {
         // arrange
@@ -447,7 +448,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('delete', () => {
-    it('should remove record as expected', () => {
+    test('should remove record as expected', () => {
       // arrange
       service.records = [
         { id: 1, someField: 'AAA' },
@@ -465,7 +466,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('deleteAsync', () => {
-    it('should remove record as expected asyncronously', () => {
+    test('should remove record as expected asyncronously', () => {
       // arrange
       service.records = [
         { id: 1, someField: 'AAA' },
@@ -483,7 +484,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('deleteMany', () => {
-    it('should remove records as expected', () => {
+    test('should remove records as expected', () => {
       // arrange
       service.records = [
         { id: 1, someField: 'AAA' },
@@ -502,7 +503,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('deleteManyAsync', () => {
-    it('should remove records as expected asyncronously', () => {
+    test('should remove records as expected asyncronously', () => {
       // arrange
       service.records = [
         { id: 1, someField: 'AAAA' },
@@ -521,7 +522,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('query', () => {
-    it('should return expected records for given predicate', () => {
+    test('should return expected records for given predicate', () => {
       // arrange
       service.records = [
         { id: 1, someField: 'AAA' },
@@ -538,7 +539,7 @@ describe('In Memory DB Service', () => {
   });
 
   describe('queryAsync', () => {
-    it(
+    test(
       'should return expected records for given predicate as observable',
       marbles(m => {
         // arrange
@@ -565,7 +566,14 @@ describe('In Memory DB Service', () => {
       someField: `${idx}`,
     });
 
-    it.each([[0, 0], [9, 9], [10, 10], [11, 11], [10, null], [10, undefined]])(
+    test.each([
+      [0, 0],
+      [9, 9],
+      [10, 10],
+      [11, 11],
+      [10, null],
+      [10, undefined],
+    ])(
       'should seed %p records given input amount of %p',
       (expectedAmount: number, inputAmount: number) => {
         // act
@@ -576,7 +584,14 @@ describe('In Memory DB Service', () => {
       },
     );
 
-    it.each([[0, 0], [9, 9], [10, 10], [11, 11], [10, null], [10, undefined]])(
+    test.each([
+      [0, 0],
+      [9, 9],
+      [10, 10],
+      [11, 11],
+      [10, null],
+      [10, undefined],
+    ])(
       'should generate correct seed records of %p given input amount of %p',
       (expectedAmount: number, inputAmount: number) => {
         // arrange

--- a/lib/services/in-memory-db.service.ts
+++ b/lib/services/in-memory-db.service.ts
@@ -5,12 +5,9 @@ import { Observable, of } from 'rxjs';
 
 @Injectable()
 export class InMemoryDBService<T extends InMemoryDBEntity> {
-  private readonly moduleConfig: Partial<InMemoryDBConfig>;
   private recordMap: { [id: number]: T } = {};
 
-  constructor(@Optional() config: Partial<InMemoryDBConfig> = {}) {
-    this.moduleConfig = config || {};
-  }
+  constructor(@Optional() private readonly config: InMemoryDBConfig) {}
 
   /**
    * Given the array of records of type `T`, reduce the array into a dictionary object of


### PR DESCRIPTION
Add support for module imports using `forFeature` method in addition to `forRoot`. This adds the ability for multiple instances of `InMemoryDBService` each with differing configurations.

Closes #59